### PR TITLE
require/include plone.behavior

### DIFF
--- a/cioppino/twothumbs/configure.zcml
+++ b/cioppino/twothumbs/configure.zcml
@@ -13,6 +13,8 @@
 
   <adapter name="positive_ratings" factory=".indexers.positive_ratings" />
 
+  <include package="plone.behavior" file="meta.zcml" />
+
   <plone:behavior
     title="Content Ratings (cioppino.twothumbs)"
     description="Adds the ability to rate content based on facebook-like thumbs."

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='cioppino.twothumbs',
       zip_safe=False,
       install_requires=[
           'setuptools',
+          'plone.behavior',
       ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
Hi,
I couldn't start my Plone instance after upgrading to cioppin.twothumbs 1.5. Adding plone.behavior as requirement in setup.py, adding an include statement in configure.zcml and re-running buildout fixed the problem.
Best regards and thanks for the package,
Thomas
