### PR TITLE
Fix like for authenticated users when anonymous voting is enabled

### DIFF
--- a/cioppino/twothumbs/browser/like.py
+++ b/cioppino/twothumbs/browser/like.py
@@ -66,13 +66,12 @@ class LikeThisShizzleView(BrowserView):
         portal_state = getMultiAdapter((self.context, self.request),
                                        name='plone_portal_state')
 
-            
-        if not anonymous_voting and portal_state.anonymous(): 
+        if not anonymous_voting and portal_state.anonymous():
             return RESPONSE.redirect('%s/login?came_from=%s' %
                                      (portal_state.portal_url(),
                                       REQUEST['HTTP_REFERER'])
                                      )
-        
+
         if anonymous_voting and portal_state.anonymous():
             anonuid = self.request.cookies.get(COOKIENAME, None)
             if anonuid is None:

--- a/cioppino/twothumbs/browser/like.py
+++ b/cioppino/twothumbs/browser/like.py
@@ -66,17 +66,17 @@ class LikeThisShizzleView(BrowserView):
         portal_state = getMultiAdapter((self.context, self.request),
                                        name='plone_portal_state')
 
-        if not anonymous_voting and portal_state.anonymous():
-            return RESPONSE.redirect('%s/login?came_from=%s' %
-                                     (portal_state.portal_url(),
-                                      REQUEST['HTTP_REFERER'])
-                                     )
-
-        if anonymous_voting and portal_state.anonymous():
-            anonuid = self.request.cookies.get(COOKIENAME, None)
-            if anonuid is None:
-                anonuid = str(uuid4())
-                RESPONSE.setCookie(COOKIENAME, anonuid)
+        if portal_state.anonymous():
+            if not anonymous_voting:
+                return RESPONSE.redirect('%s/login?came_from=%s' %
+                                         (portal_state.portal_url(),
+                                          REQUEST['HTTP_REFERER'])
+                                         )
+            else:
+                anonuid = self.request.cookies.get(COOKIENAME, None)
+                if anonuid is None:
+                    anonuid = str(uuid4())
+                    RESPONSE.setCookie(COOKIENAME, anonuid)
 
         form = self.request.form
         action = None

--- a/cioppino/twothumbs/browser/like.py
+++ b/cioppino/twothumbs/browser/like.py
@@ -62,16 +62,18 @@ class LikeThisShizzleView(BrowserView):
     def __call__(self, REQUEST, RESPONSE):
         registry = getUtility(IRegistry)
         anonuid = None
-        if not registry.get('cioppino.twothumbs.anonymousvoting', False):
-            # First check if the user is allowed to rate
-            portal_state = getMultiAdapter((self.context, self.request),
-                                           name='plone_portal_state')
-            if portal_state.anonymous():
-                return RESPONSE.redirect('%s/login?came_from=%s' %
-                                         (portal_state.portal_url(),
-                                          REQUEST['HTTP_REFERER'])
-                                         )
-        else:
+        anonymous_voting = registry.get('cioppino.twothumbs.anonymousvoting', False)
+        portal_state = getMultiAdapter((self.context, self.request),
+                                       name='plone_portal_state')
+
+            
+        if not anonymous_voting and portal_state.anonymous(): 
+            return RESPONSE.redirect('%s/login?came_from=%s' %
+                                     (portal_state.portal_url(),
+                                      REQUEST['HTTP_REFERER'])
+                                     )
+        
+        if anonymous_voting and portal_state.anonymous():
             anonuid = self.request.cookies.get(COOKIENAME, None)
             if anonuid is None:
                 anonuid = str(uuid4())

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,6 +6,8 @@ Changelog
 
 - HTML render fixes.
   [andreasma]
+- Fix bug in like view that prevented authenticated user id from being used
+  in votes when anonymous voting was enabled [cguardia]
 
 
 1.8 (2014-11-07)


### PR DESCRIPTION
The id of the current user would never be used if anonymous voting was enabled, throwing off the my vote calls.