### PR TITLE
Make visual appearance more discreet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python: 2.7
 install:
-  - sudo apt-get -qq install libfreetype6-dev liblcms1-dev libwebp-dev
+  - sudo apt-get -qq install libfreetype6-dev liblcms1-dev
   - mkdir -p buildout-cache/eggs
   - mkdir -p buildout-cache/downloads
   - python bootstrap.py -c travis.cfg

--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,11 @@ to show the thumbs.
 
 Dexterity
 ^^^^^^^^^
-Cioppino.TwoThumbs is now available as a behavior for dexterity content types. In
-the dexterity configuration UI, it will be listed under "Behaviors" for any new
-content type you create after the product has been installed. You may also
-manually add this behavior to your type by adding the following to
-../path/to/profiles/default/types/your_type.xml::
+Cioppino.TwoThumbs provides a behavior for dexterity content types. In
+the dexterity configuration UI, it will be listed under "Behaviors".
+
+You may also manually add this behavior to your type by adding the following
+to ``../path/to/profiles/default/types/your_type.xml``::
 
     ...
     <property name="behaviors">
@@ -90,14 +90,14 @@ type since it requires access to content object annotations.
 Migration
 ---------
 If you used to use plone.contentratings and want to migrate to the thumbs
-product, there is an example in the trunk of PloneSoftwareCenter. It's
-pretty easy. Please see http://svn.plone.org/svn/collective/Products.PloneSoftwareCenter/tags/1.6.1/Products/PloneSoftwareCenter/Extensions/migrateratings.py for an example.
+product, there is an example in PloneSoftwareCenter. It's
+pretty easy. Please see https://github.com/collective/Products.PloneSoftwareCenter/blob/master/Products/PloneSoftwareCenter/Extensions/migrateratings.py for an example.
 
 
 Anonymous Voting
 ----------------
 Anonymous voting is possible, but **weak**. An unique identifier is
-generated and set as cookie on fiurst vote. Then the uid is used as
+generated and set as cookie on first vote. Then the uid is used as
 identifier for later display/changes. To enable anonymous voting go to
 Plones configuration registry, search for ``cioppino.twothumbs.anonymous``
 entry and edit it. Alternativly you can add your own ``registry.xml`` to
@@ -110,13 +110,13 @@ your sites profile::
         </record>
     </registry>
 
-Its easy to fake anonymous votes, so dont trust them much. A todo here
+It's easy to fake anonymous votes, so dont trust them much. A todo here
 is to add a captcha, which would make automated vote-faking impossible.
 
 
 Bugs/Suggestions/Help
 ---------------------
-Please file bugs at https://github.com/eleddy/cioppino.twothumbs.
+Please file bugs at https://github.com/collective/cioppino.twothumbs.
 
 
 Credits

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,12 @@ skip to the section on browser views.
 Make sure you have installed or "Activated" the product if things aren't
 working as expected.
 
+Compatability
+-------------
+
+cioppino.twothumbs works with Plone 4.0, 4.1, 4.2, 4.3 and 5.0
+
+
 As a Viewlet
 ------------
 

--- a/base.cfg
+++ b/base.cfg
@@ -8,3 +8,7 @@ parts+=
 
 [code-analysis]
 directory=cioppino
+
+[versions]
+# pinned because 1.4.1 and above require coverage >= 3.7
+createcoverage = 1.4

--- a/cioppino/twothumbs/browser/javascripts/twothumbs.js
+++ b/cioppino/twothumbs/browser/javascripts/twothumbs.js
@@ -27,8 +27,9 @@ jQuery(function(jq){
 			var action = me.attr('name');
 			var upResults = form.find('.total-thumbs-up .tally-total');
 			var downResults = form.find('.total-thumbs-down .tally-total');
+			var auth_key = form.find('input[name="_authenticator"]').val();
 			if (form){
-				jq.post(form.attr("action"),action+'=FOOBAR&ajax=1', function(data) {
+				jq.post(form.attr("action"),action+'=FOOBAR&ajax=1&_authenticator='+auth_key, function(data) {
 					/* update the text */
 					upResults.text(data.ups);
 					downResults.text(data.downs);

--- a/cioppino/twothumbs/browser/javascripts/twothumbs.js
+++ b/cioppino/twothumbs/browser/javascripts/twothumbs.js
@@ -12,10 +12,10 @@ jQuery(function(jq){
 				jq('<div>').addClass('twothumbs-feedback').hide().load('./login-to-rate', function() {
 					var me = jq(this);
 					me.slideDown().find('.close-link').click(function(event) {
-						event.preventDefault(); 
+						event.preventDefault();
 						jq(this).closest('.twothumbs-feedback').slideUp();
 					});
- 
+
 				}).appendTo(container);
 			} else {
 				login.slideDown();
@@ -25,15 +25,14 @@ jQuery(function(jq){
 			// Can rate, go ahead!
 			me.blur();
 			var action = me.attr('name');
-			var summary = form.siblings('.like-summary');
-			var upResults = summary.find('.total-thumbs-up .tally-total');
-			var downResults = summary.find('.total-thumbs-down .tally-total');
+			var upResults = form.find('.total-thumbs-up .tally-total');
+			var downResults = form.find('.total-thumbs-down .tally-total');
 			if (form){
 				jq.post(form.attr("action"),action+'=FOOBAR&ajax=1', function(data) {
 					/* update the text */
 					upResults.text(data.ups);
 					downResults.text(data.downs);
-					
+
 					/* update the class */
 					form.find('.thumbs-down').removeClass('selected');
 					form.find('.thumbs-up').removeClass('selected');
@@ -44,21 +43,20 @@ jQuery(function(jq){
 					}
 
 					/* extra feedback */
-					var container = summary.closest('.thumb-rating');
-					var feedback = container.find('.twothumbs-feedback');
-					if(feedback.length>0) {
+					var feedback = form.find('.twothumbs-feedback');
+					if(feedback.length) {
 						feedback.remove();
 					}
 					var id = 'ttf-' + (new Date()).getTime();
 					jq('<div>').attr('id', id).addClass('twothumbs-feedback').html(data.msg).
 					prepend('<a class="close-link" title="' + data.close + '" href="#">&nbsp;</a>').
-					appendTo(container).hide().slideDown().find('.close-link').click(function(event) {
-						event.preventDefault(); 
+					appendTo(form).hide().slideDown().find('.close-link').click(function(event) {
+						event.preventDefault();
 						jq(this).closest('.twothumbs-feedback').slideUp();
 					});
 					setTimeout((function() {
 						jq('#' + id).slideUp();
-					}), 8000);
+					}), 2000);
 				}, 'json');
 			}
 		}

--- a/cioppino/twothumbs/browser/stylesheets/twothumbs.css
+++ b/cioppino/twothumbs/browser/stylesheets/twothumbs.css
@@ -15,7 +15,7 @@
 form input.like-button,
 form input.dislike-button {
     padding: 10px 0;
-    background-color:inherit;
+    background-color:transparent;
 	background-image: url(++resource++cioppino.twothumbs.images/thumbs-sprite.png);
     background-repeat: no-repeat;
     border-width: 0;

--- a/cioppino/twothumbs/browser/stylesheets/twothumbs.css
+++ b/cioppino/twothumbs/browser/stylesheets/twothumbs.css
@@ -12,40 +12,45 @@
     color: red;
 }
 
-
-input.like-button, input.dislike-button{
-    padding: 10px 5px;
+form input.like-button,
+form input.dislike-button {
+    padding: 10px 0;
     background-color:inherit;
 	background-image: url(++resource++cioppino.twothumbs.images/thumbs-sprite.png);
     background-repeat: no-repeat;
-    border: 1px solid #eee;
+    border-width: 0;
     cursor: pointer;
+    width: 20px;
+    text-indent: -3000px;
+    white-space: nowrap;
 }
 
-form input.like-button{
-    padding-left: 30px;
-    background-position: -39px -27px;
+form input.like-button {
+    background-position: -44px -27px;
+    padding-left: 0;
 }
 
-form input.dislike-button{
-    background-position: -13px -23px;
-    text-indent: -3000px; 
-    white-space: nowrap; 
-    width: 35px;
+.thumb-rating form {
+    text-align: right;
 }
 
-form .selected input.like-button{
-    background-position: -39px 5px;
+form input.dislike-button {
+    background-position: -18px -23px;
+    margin-left: 5px;
 }
 
-form .selected input.dislike-button{
-    background-position: -13px 10px;
+form .selected input.like-button {
+    background-position: -44px 5px;
 }
 
-.twothumbs-feedback{
+form .selected input.dislike-button {
+    background-position: -18px 10px;
+}
+
+.twothumbs-feedback {
     position: absolute;
 	z-index: 1;
-	width: 200%;
+	width: 400%;
 	margin-left: -52%;
 	padding: 4%;
 	font-size: 90%;
@@ -54,6 +59,7 @@ form .selected input.dislike-button{
 	text-align: center;
     right: 0; /* dexterity */
 }
+
 .twothumbs-feedback a.close-link:link {
 	border-bottom: 0;
 	float: right;

--- a/cioppino/twothumbs/browser/stylesheets/twothumbs.css
+++ b/cioppino/twothumbs/browser/stylesheets/twothumbs.css
@@ -3,10 +3,13 @@
 	position: relative;
 }
 
+.thumb-rating form {
+    text-align: right;
+}
+
 .total-thumbs-up .tally-total{
     color: green;
 }
-
 
 .total-thumbs-down .tally-total{
     color: red;
@@ -14,7 +17,7 @@
 
 form input.like-button,
 form input.dislike-button {
-    padding: 10px 0;
+    padding: 8px 0;
     background-color:transparent;
 	background-image: url(++resource++cioppino.twothumbs.images/thumbs-sprite.png);
     background-repeat: no-repeat;
@@ -25,13 +28,16 @@ form input.dislike-button {
     white-space: nowrap;
 }
 
+/* Reset button styles of Plone 5  */
+form input.like-button:hover,
+form input.dislike-button:hover {
+    box-shadow: none;
+    background-color: transparent;
+}
+
 form input.like-button {
     background-position: -44px -27px;
     padding-left: 0;
-}
-
-.thumb-rating form {
-    text-align: right;
 }
 
 form input.dislike-button {
@@ -57,7 +63,7 @@ form .selected input.dislike-button {
 	border: 1px solid #555;
 	background-color: #ddd;
 	text-align: center;
-    right: 0; /* dexterity */
+    right: 0;
 }
 
 .twothumbs-feedback a.close-link:link {

--- a/cioppino/twothumbs/browser/stylesheets/twothumbs.css
+++ b/cioppino/twothumbs/browser/stylesheets/twothumbs.css
@@ -17,7 +17,7 @@
 
 form input.like-button,
 form input.dislike-button {
-    padding: 8px 0;
+    padding: 10px 0 7px;
     background-color:transparent;
 	background-image: url(++resource++cioppino.twothumbs.images/thumbs-sprite.png);
     background-repeat: no-repeat;

--- a/cioppino/twothumbs/browser/templates/thumbs.pt
+++ b/cioppino/twothumbs/browser/templates/thumbs.pt
@@ -16,6 +16,7 @@
     <form action="you-know-you-like-it" method="post"
         tal:attributes="class python:canRate and 'enabled' or 'disabled';
                         action  string:${context/absolute_url}/you-know-you-like-it;">
+        <span tal:replace="structure context/@@authenticator/authenticator"/>
         <span
             tal:attributes="class   python:'thumbs-up' + (myVote==1 and ' selected' or '')">
             <input type="submit" name="form.lovinit" value="Like"

--- a/cioppino/twothumbs/browser/templates/thumbs.pt
+++ b/cioppino/twothumbs/browser/templates/thumbs.pt
@@ -22,6 +22,9 @@
                 class="allowMultiSubmit like-button" title="I like this (click again to undo)"
                 i18n:attributes="value; title"
                 tal:attributes="id  string:${context/id}_submit_like;" />
+            <span class="total-thumbs-up">
+                <span class="tally-total" tal:content="stats/ups" />
+            </span>
         </span>
         <span
             tal:attributes="class   python:'thumbs-down' + (myVote==-1 and ' selected' or '')">
@@ -29,18 +32,11 @@
                 class="allowMultiSubmit dislike-button" title="I dislike this (click again to undo)"
                 i18n:attributes="value; title"
                 tal:attributes="id  string:${context/id}_submit_dislike;"/>
+            <span class="total-thumbs-down" title="">
+                <span class="tally-total" tal:content="stats/downs" />
+            </span>
+
         </span>
     </form>
-    <div class="like-summary">
-        <span class="total-thumbs-up" i18n:translate="">
-            <span class="tally-total" tal:content="stats/ups"
-                  i18n:name="likes" /> likes,
-        </span>
-        <span class="total-thumbs-down" i18n:translate="">
-            <span class="tally-total" tal:content="stats/downs"
-                  i18n:name="dislikes" /> dislikes
-        </span>
-
-    </div>
 </div>
 </html>

--- a/cioppino/twothumbs/tests/test_view.py
+++ b/cioppino/twothumbs/tests/test_view.py
@@ -1,5 +1,5 @@
 from cioppino.twothumbs.testing import TWOTHUMBS_INTEGRATION_TESTING
-import unittest2 as unittest
+import unittest
 
 
 class TestView(unittest.TestCase):

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,7 @@ Changelog
 1.9 (unreleased)
 ----------------
 
-- Add compatability for Plone 5
+- Add compatability for Plone 5.
   [pbauer]
 
 - Make visual appearance more discreet by moving the number of votes next to

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,9 @@ Changelog
 1.9 (unreleased)
 ----------------
 
+- Add compatability for Plone 5
+  [pbauer]
+
 - Make visual appearance more discreet by moving the number of votes next to
   the thumbs and dropping the summary. Similar to the rating on youtube.
   [pbauer]
@@ -12,7 +15,8 @@ Changelog
   [andreasma]
 
 - Fix bug in like view that prevented authenticated user id from being used
-  in votes when anonymous voting was enabled [cguardia]
+  in votes when anonymous voting was enabled
+  [cguardia]
 
 
 1.8 (2014-11-07)

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,8 +4,13 @@ Changelog
 1.9 (unreleased)
 ----------------
 
+- Make visual appearance more discreet by moving the number of votes next to
+  the thumbs and dropping the summary. Similar to the rating on youtube.
+  [pbauer]
+
 - HTML render fixes.
   [andreasma]
+
 - Fix bug in like view that prevented authenticated user id from being used
   in votes when anonymous voting was enabled [cguardia]
 

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,21 @@ setup(
     # Get more strings from
     # http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
+        "Environment :: Web Environment",
         "Framework :: Plone",
+        "Framework :: Plone :: 4.1",
+        "Framework :: Plone :: 4.2",
+        "Framework :: Plone :: 4.3",
+        "Framework :: Plone :: 5.0",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Operating System :: OS Independent",
+        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     ],
     keywords='rating, content, thumbs',
     author='eleddy',
     author_email='elizabeth.leddy@gmail.com',
-    url='https://github.com/eleddy/cioppino.twothumbs',
+    url='https://github.com/collective/cioppino.twothumbs',
     license='GPL',
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['cioppino'],

--- a/travis.cfg
+++ b/travis.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/travis-4.x.cfg
-    https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/travis-4.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     base.cfg


### PR DESCRIPTION
This moves the number of votes next to the thumbs and dropps the summary. Now it looks similar to the rating on youtube. 
![rating](https://cloud.githubusercontent.com/assets/453208/12887023/eb680e1c-ce71-11e5-9ee5-c622c259c255.png)
I'm not sure if we want this change in master since it could break overridden templates. Opinions?