### PR TITLE
Fix like/dislike inline popup text translations for composed language…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix like/dislike inline popup text translations for composed language domains like nl-be.
+  [fredvd]
 
 
 2.1.1 (2016-09-12)

--- a/cioppino/twothumbs/browser/like.py
+++ b/cioppino/twothumbs/browser/like.py
@@ -3,7 +3,6 @@ try:
 except:
     # fallback to simplejson for pre python2.6
     import simplejson as json
-from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from cioppino.twothumbs import _
@@ -96,16 +95,14 @@ class LikeThisShizzleView(BrowserView):
 
             # Create handy translate function
             translate = self._get_translator()
-            ltool = getToolByName(self, 'portal_languages')
-            target_language = ltool.getPreferredLanguage()
 
             tally['msg'] = translate(
                 self._getMessage(action),
-                target_language=target_language
+                context=self.request
             )
             tally['close'] = translate(
                 _(u"Close"),
-                target_language=target_language
+                context=self.request
             )
 
             RESPONSE.setHeader('Content-Type',


### PR DESCRIPTION
… domains like nl-be.

Don't try to figure out the preferred_language, but pass the request as the translation context to the translate function.