### PR TITLE
Register collection criterions for our positive ratings field.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 2.1.3 (unreleased)
 ------------------
 
+- Register collection criterions for our positive ratings field.
+  Using it as a sorting criterion works.
+  Using it as a selection criterion (X thumbs or less/more than X thumbs)
+  needs a `fix in plone.app.querystring <https://github.com/plone/plone.app.querystring/issues/93>`_.
+  [maurits]
+
 - Fixed error: nulltranslate has no "context" argument.
   Fixes `issue 24 <https://github.com/collective/cioppino.twothumbs/issues/24>`_.
   [maurits]

--- a/cioppino/twothumbs/configure.zcml
+++ b/cioppino/twothumbs/configure.zcml
@@ -74,6 +74,17 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:upgradeSteps
+      source="1000"
+      destination="1001"
+      profile="cioppino.twothumbs:default">
+      <genericsetup:upgradeDepends
+          title="Register positive ratings criterion for collections"
+          import_profile="cioppino.twothumbs:install-base"
+          import_steps="plone.app.registry"
+          />
+  </genericsetup:upgradeSteps>
+
   <utility factory=".setuphandlers.HiddenProfiles" name="cioppino.twothumbs" />
   <utility factory=".setuphandlers.HiddenProducts" name="cioppino.twothumbs" />
 

--- a/cioppino/twothumbs/profiles/base/registry.xml
+++ b/cioppino/twothumbs/profiles/base/registry.xml
@@ -1,0 +1,15 @@
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone">
+    <records interface="plone.app.querystring.interfaces.IQueryField"
+             prefix="plone.app.querystring.field.positive_ratings">
+        <value key="title" i18n:translate="">Positive ratings</value>
+        <value key="enabled">True</value>
+        <value key="sortable">True</value>
+        <value key="operations">
+            <element>plone.app.querystring.operation.int.is</element>
+            <element>plone.app.querystring.operation.int.lessThan</element>
+            <element>plone.app.querystring.operation.int.largerThan</element>
+        </value>
+       <value key="group" i18n:translate="">Metadata</value>
+    </records>
+</registry>

--- a/cioppino/twothumbs/profiles/plone4/metadata.xml
+++ b/cioppino/twothumbs/profiles/plone4/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
   <dependencies>
     <dependency>profile-cioppino.twothumbs:install-base</dependency>
   </dependencies>

--- a/cioppino/twothumbs/profiles/plone5/metadata.xml
+++ b/cioppino/twothumbs/profiles/plone5/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
   <dependencies>
     <dependency>profile-cioppino.twothumbs:install-base</dependency>
   </dependencies>


### PR DESCRIPTION
Using it as a sorting criterion works.
Using it as a selection criterion (X thumbs or less/more than X thumbs) needs a fix in plone.app.querystring for [this issue](https://github.com/plone/plone.app.querystring/issues/93).